### PR TITLE
Allow on_behalf_of to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ GreenhouseIo.configure do |config|
 	config.symbolize_keys = true # set response keys as strings or symbols, default is false
 	config.organization = 'General Assembly'
 	config.api_token = ENV['GREENHOUSE_API_TOKEN']
+	config.on_behalf_of = ENV['GREENHOUSE_ACCOUNT_ID']
 end
 ```
 

--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -28,7 +28,7 @@ module GreenhouseIo
       get_from_harvest_api "/candidates#{path_id(id)}", options
     end
 
-    def edit_candidate(candidate_id, candidate_hash, on_behalf_of)
+    def edit_candidate(candidate_id, candidate_hash, on_behalf_of = GreenhouseIo.configuration.on_behalf_of)
       patch_to_harvest_api(
         "/candidates/#{candidate_id}",
         candidate_hash,
@@ -36,7 +36,7 @@ module GreenhouseIo
       )
     end
 
-    def add_attachment_to_candidate(candidate_id, attachment_hash, on_behalf_of)
+    def add_attachment_to_candidate(candidate_id, attachment_hash, on_behalf_of = GreenhouseIo.configuration.on_behalf_of)
       post_to_harvest_api(
         "/candidates/#{candidate_id}/attachments",
         attachment_hash,
@@ -48,7 +48,7 @@ module GreenhouseIo
       get_from_harvest_api "/candidates/#{id}/activity_feed", options
     end
 
-    def create_candidate_note(candidate_id, note_hash, on_behalf_of)
+    def create_candidate_note(candidate_id, note_hash, on_behalf_of = GreenhouseIo.configuration.on_behalf_of)
       post_to_harvest_api(
         "/candidates/#{candidate_id}/activity_feed/notes",
         note_hash,

--- a/lib/greenhouse_io/configuration.rb
+++ b/lib/greenhouse_io/configuration.rb
@@ -1,6 +1,6 @@
 module GreenhouseIo
   class Configuration
-    attr_accessor :symbolize_keys, :organization, :api_token
+    attr_accessor :symbolize_keys, :organization, :api_token, :on_behalf_of
 
     def initialize
       @symbolize_keys = false

--- a/spec/greenhouse_io/configuration_spec.rb
+++ b/spec/greenhouse_io/configuration_spec.rb
@@ -68,4 +68,26 @@ describe GreenhouseIo::Configuration do
       expect(GreenhouseIo.configuration.api_token).to eq('123FakeToken')
     end
   end
+
+  context "when no on_behalf_of id is specified" do
+    before do
+      restore_default_config
+    end
+
+    it "returns nil" do
+      expect(GreenhouseIo.configuration.on_behalf_of).to be_nil
+    end
+  end
+
+  context "when on_behalf_of id is specified" do
+    before do
+      GreenhouseIo.configure do |config|
+        config.on_behalf_of = '123FakePersonToken'
+      end
+    end
+
+    it "returns the id value" do
+      expect(GreenhouseIo.configuration.on_behalf_of).to eq('123FakePersonToken')
+    end
+  end
 end


### PR DESCRIPTION
The configuration is used as a default argument and can be overidden if
required.

I think this is a more ergonomic way to handle on_behalf_of as in my
use case I have setup an account for the server which it will operate on
behalf of.