### PR TITLE
GreenhouseIo::Errors were being constructed incorr...

### DIFF
--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -121,7 +121,7 @@ module GreenhouseIo
       if response.code == 200
         parse_json(response)
       else
-        raise GreenhouseIo::Error.new(response.code)
+        raise GreenhouseIo::Error.new("#{response.message}: #{response.parsed_response['message']}", response.code)
       end
     end
 
@@ -137,7 +137,7 @@ module GreenhouseIo
       if response.code == 200
         parse_json(response)
       else
-        raise GreenhouseIo::Error.new(response.code)
+        raise GreenhouseIo::Error.new("#{response.message}: #{response.parsed_response['message']}", response.code)
       end
     end
 
@@ -153,7 +153,7 @@ module GreenhouseIo
         if response.code == 200
           parse_json(response)
         else
-          raise GreenhouseIo::Error.new(response.code)
+          raise GreenhouseIo::Error.new("#{response.message}: #{response.parsed_response['message']}", response.code)
         end
     end
 


### PR DESCRIPTION
tly. The first argument should be the message, the second should be the
code. I corrected this for the Harvest API (client.rb). I am not using
the Job Board, so I will leave that correction for some other time.