### PR TITLE
Somehow it was working with default headers but...

### DIFF
--- a/lib/greenhouse_io/api/client.rb
+++ b/lib/greenhouse_io/api/client.rb
@@ -129,7 +129,7 @@ module GreenhouseIo
       response = post_response(url, {
         :body => JSON.dump(body),
         :basic_auth => basic_auth,
-        :headers => headers
+        :headers => headers.merge('content-type' => 'application/json;charset=utf-8')
       })
 
       set_headers_info(response.headers)
@@ -145,7 +145,7 @@ module GreenhouseIo
       response = patch_response(url, {
         :body => JSON.dump(body),
         :basic_auth => basic_auth,
-        :headers => headers
+        :headers => headers.merge('content-type' => 'application/json;charset=utf-8')
         })
 
         set_headers_info(response.headers)


### PR DESCRIPTION
...after working with the attachment endpoint I discovered that it only
uploaded the file sometimes, and returned a content-type error.
As a result I am including the correct content type on every post and
patch.